### PR TITLE
Fix WebSocket host configuration

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
   "host_permissions": [
     "http://localhost:8086/",
     "http://localhost:5000/",
-    "ws://localhost:5000/"
+    "ws://localhost:8086/"
   ],
   "background": {
     "service_worker": "background.js"

--- a/offscreen.js
+++ b/offscreen.js
@@ -1,7 +1,7 @@
 let ws;
 
 function connectWebSocket() {
-  ws = new WebSocket('ws://localhost:5000/ws');
+  ws = new WebSocket('ws://localhost:8086/ws');
 
   ws.onmessage = (event) => {
     try {


### PR DESCRIPTION
## Summary
- update WebSocket host permission to use port 8086
- connect to port 8086 in offscreen WebSocket client

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6857272151388331847f62fe5c70d607