### PR TITLE
Add speech input controls

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -10,6 +10,8 @@
 <body>
   <div id="message">メッセージがありません</div>
   <button id="play">再生する</button>
+  <button id="start-rec">音声入力開始</button>
+  <button id="stop-rec">終了</button>
   <audio id="audio-player" hidden></audio>
   <script src="popup.js"></script>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -3,9 +3,13 @@
 document.addEventListener('DOMContentLoaded', () => {
   const messageDiv = document.getElementById('message');
   const playBtn = document.getElementById('play');
+  const startBtn = document.getElementById('start-rec');
+  const stopBtn = document.getElementById('stop-rec');
   const audio = document.getElementById('audio-player');
   let messageText = '';
   let audioSrc = '';
+  startBtn.addEventListener('click', startSpeechRecognition);
+  stopBtn.addEventListener('click', stopSpeechRecognition);
 
   function playMessage() {
     if (!audioSrc) return;
@@ -37,17 +41,63 @@ document.addEventListener('DOMContentLoaded', () => {
   playBtn.addEventListener('click', playMessage);
 });
 
+let recognition;
+let recognizing = false;
+let silenceTimer;
+let collectedTranscript = '';
+
+function resetSilenceTimer() {
+  clearTimeout(silenceTimer);
+  silenceTimer = setTimeout(() => {
+    stopSpeechRecognition();
+  }, 5000);
+}
+
+function processTranscript() {
+  if (collectedTranscript) {
+    console.log('Voice Input:', collectedTranscript);
+    const messageDiv = document.getElementById('message');
+    messageDiv.textContent = collectedTranscript;
+  }
+  collectedTranscript = '';
+}
+
 function startSpeechRecognition() {
+  if (recognizing) return;
   const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
   if (!SpeechRecognition) {
     console.warn('SpeechRecognition API not supported');
     return;
   }
-  const recognition = new SpeechRecognition();
+  recognition = new SpeechRecognition();
   recognition.lang = 'ja-JP';
+  recognition.continuous = true;
+  recognition.interimResults = false;
+  collectedTranscript = '';
   recognition.onresult = (event) => {
-    const transcript = event.results[0][0].transcript;
-    console.log('Voice Input:', transcript);
+    for (let i = event.resultIndex; i < event.results.length; i++) {
+      collectedTranscript += event.results[i][0].transcript;
+    }
+    resetSilenceTimer();
+  };
+  recognition.onstart = () => {
+    recognizing = true;
+    resetSilenceTimer();
+  };
+  recognition.onerror = (e) => {
+    console.error('Speech recognition error', e);
+    stopSpeechRecognition();
+  };
+  recognition.onend = () => {
+    recognizing = false;
+    clearTimeout(silenceTimer);
+    processTranscript();
   };
   recognition.start();
+}
+
+function stopSpeechRecognition() {
+  if (recognizing && recognition) {
+    recognition.stop();
+  }
 }


### PR DESCRIPTION
## Summary
- add buttons to control speech input start/stop
- start speech recognition automatically after playing audio
- stop listening after 5 seconds of silence
- update popup script with manual control and silence timer

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6858987149808331a9f85afe23efa9bf